### PR TITLE
Comment out Hinge constartint methods to expose only two options.

### DIFF
--- a/Sources/bullet/bullet.idl
+++ b/Sources/bullet/bullet.idl
@@ -531,8 +531,8 @@ btConeTwistConstraint implements btTypedConstraint;
 interface btHingeConstraint {
 	void btHingeConstraint ([Ref] btRigidBody rbA, [Ref] btRigidBody rbB, [Ref] btVector3 pivotInA, [Ref] btVector3 pivotInB, [Ref] btVector3 axisInA, [Ref] btVector3 axisInB, optional boolean useReferenceFrameA);
 	void btHingeConstraint ([Ref] btRigidBody rbA, [Ref] btVector3 pivotInA, [Ref] btVector3 axisInA, optional boolean useReferenceFrameA);
-	void btHingeConstraint ([Ref] btRigidBody rbA, [Ref] btRigidBody rbB, [Ref] btTransform rbAFrame, [Ref] btTransform rbBFrame, optional boolean useReferenceFrameA);
-	void btHingeConstraint ([Ref] btRigidBody rbA, [Ref] btTransform rbAFrame, optional boolean useReferenceFrameA);
+	//void btHingeConstraint ([Ref] btRigidBody rbA, [Ref] btRigidBody rbB, [Ref] btTransform rbAFrame, [Ref] btTransform rbBFrame, optional boolean useReferenceFrameA);
+	//void btHingeConstraint ([Ref] btRigidBody rbA, [Ref] btTransform rbAFrame, optional boolean useReferenceFrameA);
 
 	void setLimit(float low, float high, float softness, float biasFactor, optional float relaxationFactor);
 	void enableAngularMotor(boolean enableMotor, float targetVelocity, float maxMotorImpulse);


### PR DESCRIPTION
This avoids a possible compile-time error.

